### PR TITLE
Fix (Abide): Restore default submit behavior

### DIFF
--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -66,7 +66,6 @@ class Abide extends Plugin {
       .off('click.zf.abide keydown.zf.abide')
       .on('click.zf.abide keydown.zf.abide', (e) => {
         if (!e.key || (e.key === ' ' || e.key === 'Enter')) {
-          e.preventDefault();
           this.formnovalidate = e.target.getAttribute('formnovalidate') !== null;
           this.$element.submit();
         }


### PR DESCRIPTION
## Description

Fixes the default form submission behavior for Abide enabled forms.

The default behavior of HTML forms is to submit the name/value pairs for a submit button along with the name/value pairs of the other input elements.

Usage of `e.preventDefault()` for some reason stops the name/value pairs for a submit button from being sent on form submission.

By removing `e.preventDefault()`, the default HTML form functionality is restored and the key/value of the submit button is sent as part of the form submission.

This removal does not change the functionality of Abide according to the unit tests.
- Closes #12066


## Types of changes
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (anything that would change an existing functionality)
- [ ] Maintenance (refactor, code cleaning, development tools...)


## Checklist
- [x] I have read and follow the CONTRIBUTING.md document.
- [x] The pull request title and template are correctly filled.
- [x] The pull request targets the right branch (`develop` or `develop-v...`).
- [x] My commits are correctly titled and contain all relevant information.
- [ ] I have updated the documentation accordingly to my changes (if relevant).
- [ ] I have added tests to cover my changes (if relevant).
